### PR TITLE
feat: use headless UI for calendar selector

### DIFF
--- a/app/frontend/components/calendarIcon.tsx
+++ b/app/frontend/components/calendarIcon.tsx
@@ -2,38 +2,39 @@ import Image from 'next/image'
 
 export type CalendarIconChildPosition = 'left' | 'right'
 
-export interface ICalendarIconProps {
+export interface CalendarIconProps {
   title?: string
   onClick?: () => void
   src: string
   className?: string
   children?: JSX.Element
   childPosition?: CalendarIconChildPosition
+  size?: number
 }
 
-const CalendarIcon = (props: ICalendarIconProps): JSX.Element => {
-  const handleClick = () => {
-    if (props.onClick) {
-      props.onClick()
-    }
-  }
+const CalendarIcon = ({
+  title = 'Calendar icon',
+  onClick,
+  src,
+  className,
+  children,
+  childPosition = 'right',
+  size = 24,
+}: CalendarIconProps): JSX.Element => {
+  let classNames = className
 
-  const childPosition: CalendarIconChildPosition = props.childPosition || 'right'
-  let classNames = props.className
-
-  if (props.onClick) {
+  if (onClick) {
     classNames = classNames + ' opacity-60 hover:opacity-100'
   }
 
   return (
     <div
-      title={props.title && props.title.length > 0 ? props.title : 'Calendar icon'}
-      onClick={handleClick}
-      className="flex items-center cursor-pointer"
+      title={title}
+      onClick={onClick}
+      className={`flex items-center cursor-pointer ${childPosition === 'left' ? 'flex-row' : 'flex-row-reverse'}`}
     >
-      {props.children && childPosition === 'left' && props.children}
-      <Image className={classNames} src={props.src} />
-      {props.children && childPosition === 'right' && props.children}
+      <div>{children}</div>
+      <Image className={classNames} src={src} width={size} height={size} />
     </div>
   )
 }

--- a/app/frontend/components/hourInput.spec.tsx
+++ b/app/frontend/components/hourInput.spec.tsx
@@ -7,12 +7,7 @@ describe('the hour input control should display ...', () => {
   beforeEach(() => {
     render(
       <>
-        <HourInput
-          workHours={0}
-          onChange={(workHours): void => {
-            console.log(workHours)
-          }}
-        />
+        <HourInput workHours={0} onChange={jest.fn()} />
         <button>Click me!</button>
       </>,
     )

--- a/app/frontend/components/projectForm/projectForm.tsx
+++ b/app/frontend/components/projectForm/projectForm.tsx
@@ -46,8 +46,10 @@ export const ProjectForm = (props: ProjectFormProps): JSX.Element => {
         {formState.errors.title && <span>Required</span>}
       </label>
       <div className="flex flex-wrap gap-x-5">
-        <label>
-          <span>Start</span>
+        <div>
+          <label htmlFor="start" className="block pl-0.5 text-gray-500">
+            Start
+          </label>
           <div className="flex items-center gap-x-2">
             <Controller
               control={control}
@@ -60,10 +62,10 @@ export const ProjectForm = (props: ProjectFormProps): JSX.Element => {
                   onBlur={onBlur}
                   onChange={onChange}
                   value={value ?? undefined}
+                  id="start"
                 />
               )}
             />
-
             <CalendarSelector
               disabled={formState.isSubmitting}
               className="flex-shrink-0"
@@ -71,11 +73,13 @@ export const ProjectForm = (props: ProjectFormProps): JSX.Element => {
               onSelectedDateChange={(newDate) => setValue('start', format(newDate, 'yyyy-MM-dd'))}
             />
           </div>
-          {formState.errors.start && <span className="whitespace-nowrap">Invalid Date</span>}
-        </label>
+        </div>
+        {formState.errors.start && <span className="whitespace-nowrap">Invalid Date</span>}
 
-        <label>
-          <span>End</span>
+        <div>
+          <label htmlFor="end" className="block pl-0.5 text-gray-500">
+            End
+          </label>
           <div className="flex items-center gap-x-2">
             <Controller
               control={control}
@@ -88,6 +92,7 @@ export const ProjectForm = (props: ProjectFormProps): JSX.Element => {
                   onBlur={onBlur}
                   onChange={onChange}
                   value={value ?? undefined}
+                  id="end"
                 />
               )}
             />
@@ -99,7 +104,7 @@ export const ProjectForm = (props: ProjectFormProps): JSX.Element => {
             />
           </div>
           {formState.errors.end && <span className="whitespace-nowrap">Invalid Date</span>}
-        </label>
+        </div>
       </div>
       <div className="flex justify-center mt-16 gap-2">
         <Button disabled={formState.isSubmitting} variant="secondary" onClick={onCancel} tooltip="Cancel the changes">

--- a/app/jest-setup.js
+++ b/app/jest-setup.js
@@ -8,4 +8,3 @@ jest.mock('next/image', () => ({
     return 'Next image stub' // whatever
   },
 }))
-console.log('jest setup done...')


### PR DESCRIPTION
- Headless UI for `CalendarSelector`
- fix Image bug in `CalendarIcon` (widht and height was missing)