### PR TITLE
feat(graphql): add Team type, queries and mutations

### DIFF
--- a/app/backend/graphql/generated/nexus-typegen.ts
+++ b/app/backend/graphql/generated/nexus-typegen.ts
@@ -48,9 +48,17 @@ export interface NexusGenInputs {
     projectId: number // Int!
     title: string // String!
   }
+  TeamInput: {
+    // input type
+    slug: string // String!
+    theme?: NexusGenEnums['Theme'] | null // Theme
+    title: string // String!
+  }
 }
 
-export interface NexusGenEnums {}
+export interface NexusGenEnums {
+  Theme: 'BLUE' | 'GRAY' | 'GREEN' | 'INDIGO' | 'PINK' | 'PURPLE' | 'RED' | 'YELLOW'
+}
 
 export interface NexusGenScalars {
   String: string
@@ -67,6 +75,14 @@ export interface NexusGenObjects {
   Project: prisma.Project
   Query: {}
   Task: prisma.Task
+  Team: {
+    // root type
+    id: string // ID!
+    inviteKey: string // String!
+    slug: string // String!
+    theme: NexusGenEnums['Theme'] // Theme!
+    title: string // String!
+  }
   WorkHour: prisma.WorkHour
 }
 
@@ -76,7 +92,7 @@ export interface NexusGenUnions {}
 
 export type NexusGenRootTypes = NexusGenObjects
 
-export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars
+export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars & NexusGenEnums
 
 export interface NexusGenFieldTypes {
   Mutation: {
@@ -87,6 +103,10 @@ export interface NexusGenFieldTypes {
     projectUpdate: NexusGenRootTypes['Project'] // Project!
     taskCreate: NexusGenRootTypes['Task'] // Task!
     taskDelete: NexusGenRootTypes['Task'] // Task!
+    teamAcceptInvite: NexusGenRootTypes['Team'] // Team!
+    teamCreate: NexusGenRootTypes['Team'] // Team!
+    teamDelete: NexusGenRootTypes['Team'] // Team!
+    teamUpdate: NexusGenRootTypes['Team'] // Team!
   }
   Project: {
     // field return type
@@ -101,6 +121,9 @@ export interface NexusGenFieldTypes {
     // field return type
     project: NexusGenRootTypes['Project'] // Project!
     projects: NexusGenRootTypes['Project'][] // [Project!]!
+    team: NexusGenRootTypes['Team'] // Team!
+    teamBySlug: NexusGenRootTypes['Team'] // Team!
+    teams: NexusGenRootTypes['Team'][] // [Team!]!
   }
   Task: {
     // field return type
@@ -108,6 +131,14 @@ export interface NexusGenFieldTypes {
     project: NexusGenRootTypes['Project'] // Project!
     title: string // String!
     workhours: NexusGenRootTypes['WorkHour'][] // [WorkHour!]!
+  }
+  Team: {
+    // field return type
+    id: string // ID!
+    inviteKey: string // String!
+    slug: string // String!
+    theme: NexusGenEnums['Theme'] // Theme!
+    title: string // String!
   }
   WorkHour: {
     // field return type
@@ -128,6 +159,10 @@ export interface NexusGenFieldTypeNames {
     projectUpdate: 'Project'
     taskCreate: 'Task'
     taskDelete: 'Task'
+    teamAcceptInvite: 'Team'
+    teamCreate: 'Team'
+    teamDelete: 'Team'
+    teamUpdate: 'Team'
   }
   Project: {
     // field return type name
@@ -142,6 +177,9 @@ export interface NexusGenFieldTypeNames {
     // field return type name
     project: 'Project'
     projects: 'Project'
+    team: 'Team'
+    teamBySlug: 'Team'
+    teams: 'Team'
   }
   Task: {
     // field return type name
@@ -149,6 +187,14 @@ export interface NexusGenFieldTypeNames {
     project: 'Project'
     title: 'String'
     workhours: 'WorkHour'
+  }
+  Team: {
+    // field return type name
+    id: 'ID'
+    inviteKey: 'String'
+    slug: 'String'
+    theme: 'Theme'
+    title: 'String'
   }
   WorkHour: {
     // field return type name
@@ -190,11 +236,36 @@ export interface NexusGenArgTypes {
       // args
       id: string // ID!
     }
+    teamAcceptInvite: {
+      // args
+      inviteKey: string // String!
+    }
+    teamCreate: {
+      // args
+      data: NexusGenInputs['TeamInput'] // TeamInput!
+    }
+    teamDelete: {
+      // args
+      id: string // ID!
+    }
+    teamUpdate: {
+      // args
+      data: NexusGenInputs['TeamInput'] // TeamInput!
+      id: string // ID!
+    }
   }
   Query: {
     project: {
       // args
       projectId: string // ID!
+    }
+    team: {
+      // args
+      id: string // ID!
+    }
+    teamBySlug: {
+      // args
+      slug: string // String!
     }
   }
 }
@@ -207,7 +278,7 @@ export type NexusGenObjectNames = keyof NexusGenObjects
 
 export type NexusGenInputNames = keyof NexusGenInputs
 
-export type NexusGenEnumNames = never
+export type NexusGenEnumNames = keyof NexusGenEnums
 
 export type NexusGenInterfaceNames = never
 

--- a/app/backend/graphql/generated/schema.graphql
+++ b/app/backend/graphql/generated/schema.graphql
@@ -62,6 +62,43 @@ type Mutation {
     """
     id: ID!
   ): Task!
+
+  """
+  Accept an invite to a team
+  """
+  teamAcceptInvite(
+    """
+    Invite key of the team
+    """
+    inviteKey: String!
+  ): Team!
+
+  """
+  Create a new team
+  """
+  teamCreate(data: TeamInput!): Team!
+
+  """
+  Delete a new team
+  """
+  teamDelete(
+    """
+    Id of the team
+    """
+    id: ID!
+  ): Team!
+
+  """
+  Update a new team
+  """
+  teamUpdate(
+    data: TeamInput!
+
+    """
+    Id of the team
+    """
+    id: ID!
+  ): Team!
 }
 
 type Project {
@@ -98,6 +135,31 @@ type Query {
   Returns a list of all projects
   """
   projects: [Project!]!
+
+  """
+  Return a team by an id
+  """
+  team(
+    """
+    Id of the team
+    """
+    id: ID!
+  ): Team!
+
+  """
+  Return a team by a slug
+  """
+  teamBySlug(
+    """
+    slug of the team
+    """
+    slug: String!
+  ): Team!
+
+  """
+  Return all teams
+  """
+  teams: [Team!]!
 }
 
 type Task {
@@ -117,6 +179,57 @@ type Task {
 input TaskInput {
   projectId: Int!
   title: String!
+}
+
+type Team {
+  """
+  Identifier of the team
+  """
+  id: ID!
+  inviteKey: String!
+
+  """
+  Slug that is used in the team URL
+  """
+  slug: String!
+
+  """
+  Color theme of the team
+  """
+  theme: Theme!
+
+  """
+  Title of the team
+  """
+  title: String!
+}
+
+input TeamInput {
+  """
+  Slug that is used in the team URL
+  """
+  slug: String!
+
+  """
+  Color theme of the team
+  """
+  theme: Theme
+
+  """
+  Title of the team
+  """
+  title: String!
+}
+
+enum Theme {
+  BLUE
+  GRAY
+  GREEN
+  INDIGO
+  PINK
+  PURPLE
+  RED
+  YELLOW
 }
 
 """

--- a/app/backend/graphql/schema.ts
+++ b/app/backend/graphql/schema.ts
@@ -7,6 +7,15 @@ import { TimeScalar } from './scalars/time'
 import { projectCreateMutationField, projectDeleteMutationField, projectUpdateMutationField } from './project/mutations'
 import { taskCreateMutationField, taskDeleteMutationField } from './task'
 import { projectQueryField } from './project/queries/projectQueryField'
+import {
+  teamAcceptInviteMutationField,
+  teamBySlugQueryField,
+  teamCreateMutationField,
+  teamDeleteMutationField,
+  teamQueryField,
+  teamsQueryField,
+  teamUpdateMutationField,
+} from './team'
 
 export const schema = makeSchema({
   types: [
@@ -20,6 +29,14 @@ export const schema = makeSchema({
     projectUpdateMutationField,
     taskCreateMutationField,
     taskDeleteMutationField,
+
+    teamsQueryField,
+    teamQueryField,
+    teamBySlugQueryField,
+    teamAcceptInviteMutationField,
+    teamCreateMutationField,
+    teamUpdateMutationField,
+    teamDeleteMutationField,
   ],
   outputs: {
     typegen: path.join(process.env.ROOT ?? '', '/backend/graphql/generated', 'nexus-typegen.ts'),

--- a/app/backend/graphql/team/index.ts
+++ b/app/backend/graphql/team/index.ts
@@ -1,0 +1,3 @@
+export * from './team'
+export * from './queries'
+export * from './mutations'

--- a/app/backend/graphql/team/mutations/index.ts
+++ b/app/backend/graphql/team/mutations/index.ts
@@ -1,0 +1,4 @@
+export * from './teamAcceptInviteMutationField'
+export * from './teamCreateMutationField'
+export * from './teamDeleteMutationField'
+export * from './teamUpdateMutationField'

--- a/app/backend/graphql/team/mutations/teamAcceptInviteMutationField.ts
+++ b/app/backend/graphql/team/mutations/teamAcceptInviteMutationField.ts
@@ -1,0 +1,39 @@
+import { mutationField, stringArg } from 'nexus'
+import { Team } from '../team'
+
+export const teamAcceptInviteMutationField = mutationField('teamAcceptInvite', {
+  type: Team,
+  description: 'Accept an invite to a team',
+  args: {
+    inviteKey: stringArg({ description: 'Invite key of the team' }),
+  },
+  authorize: (_source, _arguments, context) => !!context.session?.user,
+  resolve: async (_source, { inviteKey }, context) => {
+    if (!context.session?.user) {
+      throw new Error('not authenticated')
+    }
+    // Does membership already exists?
+    const team = await context.prisma.teamMembership
+      .findFirst({
+        where: {
+          userId: context.session.user.id,
+          team: { inviteKey },
+        },
+      })
+      .team()
+
+    if (team) {
+      return team
+    }
+
+    // Create new membership
+    return context.prisma.team.update({
+      where: { inviteKey },
+      data: {
+        teamMemberships: {
+          create: { userId: context.session.user.id },
+        },
+      },
+    })
+  },
+})

--- a/app/backend/graphql/team/mutations/teamCreateMutationField.ts
+++ b/app/backend/graphql/team/mutations/teamCreateMutationField.ts
@@ -1,0 +1,30 @@
+import { arg, mutationField } from 'nexus'
+import { Team } from '../team'
+import { TeamInput } from '../teamInput'
+
+export const teamCreateMutationField = mutationField('teamCreate', {
+  type: Team,
+  description: 'Create a new team',
+  args: {
+    data: arg({ type: TeamInput }),
+  },
+  authorize: (_source, _arguments, context) => !!context.session?.user.id,
+  resolve: (_source, { data: { title, slug, theme } }, context) => {
+    if (!context.session?.user) {
+      throw new Error('not authenticated')
+    }
+
+    return context.prisma.team.create({
+      data: {
+        title,
+        slug,
+        theme: theme ?? undefined,
+        teamMemberships: {
+          create: {
+            userId: context.session.user.id,
+          },
+        },
+      },
+    })
+  },
+})

--- a/app/backend/graphql/team/mutations/teamDeleteMutationField.ts
+++ b/app/backend/graphql/team/mutations/teamDeleteMutationField.ts
@@ -1,0 +1,19 @@
+import { idArg, mutationField } from 'nexus'
+import { Team } from '../team'
+import { isTeamMember } from '../utils'
+
+export const teamDeleteMutationField = mutationField('teamDelete', {
+  type: Team,
+  description: 'Delete a new team',
+  args: {
+    id: idArg({ description: 'Id of the team' }),
+  },
+  authorize: (_source, { id }, context) => isTeamMember({ id }, context),
+  resolve: (_source, { id }, context) => {
+    if (!context.session?.user) {
+      throw new Error('not authenticated')
+    }
+
+    return context.prisma.team.delete({ where: { id } })
+  },
+})

--- a/app/backend/graphql/team/mutations/teamUpdateMutationField.ts
+++ b/app/backend/graphql/team/mutations/teamUpdateMutationField.ts
@@ -1,0 +1,28 @@
+import { arg, idArg, mutationField } from 'nexus'
+import { Team } from '../team'
+import { TeamInput } from '../teamInput'
+import { isTeamMember } from '../utils'
+
+export const teamUpdateMutationField = mutationField('teamUpdate', {
+  type: Team,
+  description: 'Update a new team',
+  args: {
+    id: idArg({ description: 'Id of the team' }),
+    data: arg({ type: TeamInput }),
+  },
+  authorize: async (_source, { id }, context) => isTeamMember({ id }, context),
+  resolve: (_source, { id, data: { title, slug, theme } }, context) => {
+    if (!context.session?.user) {
+      throw new Error('not authenticated')
+    }
+
+    return context.prisma.team.update({
+      where: { id },
+      data: {
+        title,
+        slug,
+        theme: theme ?? undefined,
+      },
+    })
+  },
+})

--- a/app/backend/graphql/team/queries/index.ts
+++ b/app/backend/graphql/team/queries/index.ts
@@ -1,0 +1,3 @@
+export * from './teamsQueryField'
+export * from './teamQueryField'
+export * from './teamBySlugQueryField'

--- a/app/backend/graphql/team/queries/teamBySlugQueryField.ts
+++ b/app/backend/graphql/team/queries/teamBySlugQueryField.ts
@@ -1,0 +1,17 @@
+import { queryField, stringArg } from 'nexus'
+import { Team } from '../team'
+import { isTeamMember } from '../utils'
+
+export const teamBySlugQueryField = queryField('teamBySlug', {
+  type: Team,
+  description: 'Return a team by a slug',
+  args: {
+    slug: stringArg({ description: 'slug of the team' }),
+  },
+  authorize: (_source, { slug }, context) => isTeamMember({ slug }, context),
+  resolve: (_source, { slug }, context) =>
+    context.prisma.team.findUnique({
+      where: { slug },
+      rejectOnNotFound: true,
+    }),
+})

--- a/app/backend/graphql/team/queries/teamQueryField.ts
+++ b/app/backend/graphql/team/queries/teamQueryField.ts
@@ -1,0 +1,17 @@
+import { idArg, queryField } from 'nexus'
+import { Team } from '../team'
+import { isTeamMember } from '../utils'
+
+export const teamQueryField = queryField('team', {
+  type: Team,
+  description: 'Return a team by an id',
+  args: {
+    id: idArg({ description: 'Id of the team' }),
+  },
+  authorize: (_source, { id }, context) => isTeamMember({ id }, context),
+  resolve: (_source, { id }, context) =>
+    context.prisma.team.findUnique({
+      where: { id },
+      rejectOnNotFound: true,
+    }),
+})

--- a/app/backend/graphql/team/queries/teamsQueryField.ts
+++ b/app/backend/graphql/team/queries/teamsQueryField.ts
@@ -1,0 +1,19 @@
+import { list, queryField } from 'nexus'
+import { Team } from '../team'
+
+export const teamsQueryField = queryField('teams', {
+  type: list(Team),
+  description: 'Return all teams',
+  authorize: (_source, _arguments, context) => !!context.session?.user.id,
+  resolve: (_source, _arguments, context) => {
+    if (!context.session?.user) {
+      throw new Error('User not authenticated')
+    }
+
+    return context.prisma.team.findMany({
+      where: {
+        teamMemberships: { some: { userId: context.session.user.id } },
+      },
+    })
+  },
+})

--- a/app/backend/graphql/team/team.ts
+++ b/app/backend/graphql/team/team.ts
@@ -1,0 +1,16 @@
+import { objectType } from 'nexus'
+import { Theme } from './theme'
+
+export const Team = objectType({
+  name: 'Team',
+  definition: (t) => {
+    t.id('id', { description: 'Identifier of the team' })
+    t.string('title', { description: 'Title of the team' })
+    t.string('slug', { description: 'Slug that is used in the team URL' })
+    t.field('theme', {
+      type: Theme,
+      description: 'Color theme of the team',
+    })
+    t.string('inviteKey')
+  },
+})

--- a/app/backend/graphql/team/teamInput.ts
+++ b/app/backend/graphql/team/teamInput.ts
@@ -1,0 +1,14 @@
+import { inputObjectType } from 'nexus'
+import { Theme } from './theme'
+
+export const TeamInput = inputObjectType({
+  name: 'TeamInput',
+  definition: (t) => {
+    t.string('title', { description: 'Title of the team' })
+    t.string('slug', { description: 'Slug that is used in the team URL' })
+    t.nullable.field('theme', {
+      type: Theme,
+      description: 'Color theme of the team',
+    })
+  },
+})

--- a/app/backend/graphql/team/theme.ts
+++ b/app/backend/graphql/team/theme.ts
@@ -1,0 +1,6 @@
+import { enumType } from 'nexus'
+
+export const Theme = enumType({
+  name: 'Theme',
+  members: ['GRAY', 'RED', 'YELLOW', 'GREEN', 'BLUE', 'INDIGO', 'PURPLE', 'PINK'],
+})

--- a/app/backend/graphql/team/utils/index.ts
+++ b/app/backend/graphql/team/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './isTeamMember'

--- a/app/backend/graphql/team/utils/isTeamMember.ts
+++ b/app/backend/graphql/team/utils/isTeamMember.ts
@@ -1,0 +1,19 @@
+import { Prisma } from '@prisma/client'
+import { Context } from '../../context'
+
+export const isTeamMember = async (teamWhere: Prisma.TeamWhereUniqueInput, context: Context): Promise<boolean> => {
+  if (!context.session?.user) {
+    return false
+  }
+
+  const team = await context.prisma.team.findFirst({
+    where: {
+      ...teamWhere,
+      teamMemberships: {
+        some: { userId: context.session.user.id },
+      },
+    },
+  })
+
+  return !!team
+}

--- a/app/frontend/generated/graphql.ts
+++ b/app/frontend/generated/graphql.ts
@@ -34,6 +34,14 @@ export type Mutation = {
   taskCreate: Task
   /** Delete a task */
   taskDelete: Task
+  /** Accept an invite to a team */
+  teamAcceptInvite: Team
+  /** Create a new team */
+  teamCreate: Team
+  /** Delete a new team */
+  teamDelete: Team
+  /** Update a new team */
+  teamUpdate: Team
 }
 
 export type MutationCreateWorkHourArgs = {
@@ -64,6 +72,23 @@ export type MutationTaskDeleteArgs = {
   id: Scalars['ID']
 }
 
+export type MutationTeamAcceptInviteArgs = {
+  inviteKey: Scalars['String']
+}
+
+export type MutationTeamCreateArgs = {
+  data: TeamInput
+}
+
+export type MutationTeamDeleteArgs = {
+  id: Scalars['ID']
+}
+
+export type MutationTeamUpdateArgs = {
+  data: TeamInput
+  id: Scalars['ID']
+}
+
 export type Project = {
   __typename?: 'Project'
   endDate?: Maybe<Scalars['Date']>
@@ -87,10 +112,24 @@ export type Query = {
   project: Project
   /** Returns a list of all projects */
   projects: Array<Project>
+  /** Return a team by an id */
+  team: Team
+  /** Return a team by a slug */
+  teamBySlug: Team
+  /** Return all teams */
+  teams: Array<Team>
 }
 
 export type QueryProjectArgs = {
   projectId: Scalars['ID']
+}
+
+export type QueryTeamArgs = {
+  id: Scalars['ID']
+}
+
+export type QueryTeamBySlugArgs = {
+  slug: Scalars['String']
 }
 
 export type Task = {
@@ -106,6 +145,39 @@ export type Task = {
 export type TaskInput = {
   projectId: Scalars['Int']
   title: Scalars['String']
+}
+
+export type Team = {
+  __typename?: 'Team'
+  /** Identifier of the team */
+  id: Scalars['ID']
+  inviteKey: Scalars['String']
+  /** Slug that is used in the team URL */
+  slug: Scalars['String']
+  /** Color theme of the team */
+  theme: Theme
+  /** Title of the team */
+  title: Scalars['String']
+}
+
+export type TeamInput = {
+  /** Slug that is used in the team URL */
+  slug: Scalars['String']
+  /** Color theme of the team */
+  theme?: Maybe<Theme>
+  /** Title of the team */
+  title: Scalars['String']
+}
+
+export enum Theme {
+  Blue = 'BLUE',
+  Gray = 'GRAY',
+  Green = 'GREEN',
+  Indigo = 'INDIGO',
+  Pink = 'PINK',
+  Purple = 'PURPLE',
+  Red = 'RED',
+  Yellow = 'YELLOW',
 }
 
 export type WorkHour = {


### PR DESCRIPTION
Added to GraphQL:
 - `Team` type
 - `Theme` enum
 - `teams` query
 - `team` query
 - `teamBySlug` query
 - `teamAcceptInvite` mutation
 - `teamCreate` mutation
 - `teamDelete` mutation
 - `teamUpdate` mutation

TODO:
- [ ] create a connection with User type (waiting for #117); but maybe we should do it in another PR