### PR TITLE
ci: run GitHub actions on main

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,6 @@ name: Node.js CI
 
 on:
   push:
-    branches:
-      - "**" # matches every branch
-      - "!main" # excludes master
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
We should make sure that our main branch is always green. In my opinion, the exclude does not make sense.