### PR TITLE
ci: fix DigitaOcean deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next
+.git
+.turbo
+**/node_modules
+**/.turbo
+**/.next

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:16-alpine AS builder
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+RUN apk update
+# Set working directory
+WORKDIR /app
+RUN npm install --global turbo
+COPY . .
+RUN turbo prune --scope=@progwise/timebook-web --docker
+
+# Add lockfile and package.json's of isolated subworkspace
+FROM node:16-alpine AS installer
+RUN apk add --no-cache libc6-compat
+RUN apk update
+RUN npm install --global pnpm
+WORKDIR /app
+
+# First install the dependencies (as they change less often)
+COPY .gitignore .gitignore
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/out/full/packages/backend/src/prisma/schema.prisma ./packages/backend/src/prisma/schema.prisma
+RUN pnpm install --frozen-lockfile
+
+# Build the project
+COPY --from=builder /app/out/full/ .
+# COPY turbo.json turbo.json
+RUN pnpm turbo run build --filter=@progwise/timebook-web
+
+CMD pnpm run --prefix apps/web start

--- a/packages/pulumi/index.ts
+++ b/packages/pulumi/index.ts
@@ -10,7 +10,6 @@ export const timebook = new digitalocean.App('timebook', {
     region: 'fra1',
     services: [
       {
-        environmentSlug: 'node-js',
         git: {
           branch: 'main',
           repoCloneUrl: 'https://github.com/progwise/timebook',
@@ -18,8 +17,7 @@ export const timebook = new digitalocean.App('timebook', {
         instanceCount: 1,
         name: 'timebook',
         instanceSizeSlug: 'basic-xxs',
-        buildCommand: 'npm install -g pnpm && pnpm install && pnpm run build',
-        runCommand: 'pnpm run start',
+        dockerfilePath: 'Dockerfile',
         envs: [
           { key: 'NEXTAUTH_URL', value: '${_self.PUBLIC_URL}' },
           { key: 'NEXTAUTH_SECRET', value: process.env.NEXTAUTH_SECRET, type: 'SECRET' },


### PR DESCRIPTION
closes #535

Changes:
- Add a Dockerfile
- Update pulumi config to use the new Dockerfile on DigitalOcean

I tried to use the [Next.js Standalone mode](https://nextjs.org/docs/advanced-features/output-file-tracing). However, there is currently a bug (disscused here: https://github.com/vercel/next.js/discussions/39432)