### PR TITLE
ci: Remove Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: weekly
-      day: friday


### PR DESCRIPTION
At the moment, dependabot does not support pnpm. Let's remove it for now.