### PR TITLE
test(backend): use gql tag in backend tests

### DIFF
--- a/packages/backend/src/graphql/project/mutations/projectUpdateMutationField.test.ts
+++ b/packages/backend/src/graphql/project/mutations/projectUpdateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const projectUpdateMutation = `
+const projectUpdateMutation = gql`
   mutation projectUpdateMutation($id: ID!, $data: ProjectInput!) {
     projectUpdate(id: $id, data: $data) {
       id

--- a/packages/backend/src/graphql/projectMembership/mutations/projectMembershipCreateMutationField.test.ts
+++ b/packages/backend/src/graphql/projectMembership/mutations/projectMembershipCreateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,12 +7,15 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const projectMembershipCreateMutation = `
-mutation projectMembershipCreate($userID: ID!, $projectID: ID!) {
-  projectMembershipCreate(userId: $userID, projectId: $projectID) {
-    title, members{id}
+const projectMembershipCreateMutation = gql`
+  mutation projectMembershipCreate($userID: ID!, $projectID: ID!) {
+    projectMembershipCreate(userId: $userID, projectId: $projectID) {
+      title
+      members {
+        id
+      }
+    }
   }
-}
 `
 beforeEach(async () => {
   await prisma.user.createMany({

--- a/packages/backend/src/graphql/projectMembership/mutations/projectMembershipDeleteMutationField.test.ts
+++ b/packages/backend/src/graphql/projectMembership/mutations/projectMembershipDeleteMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,12 +7,15 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const projectMembershipDeleteMutation = `
-mutation projectMembershipDelete($userID: ID!, $projectID: ID!) {
-  projectMembershipDelete(userId: $userID, projectId: $projectID) {
-    title, members{id}
+const projectMembershipDeleteMutation = gql`
+  mutation projectMembershipDelete($userID: ID!, $projectID: ID!) {
+    projectMembershipDelete(userId: $userID, projectId: $projectID) {
+      title
+      members {
+        id
+      }
+    }
   }
-}
 `
 beforeEach(async () => {
   await prisma.user.createMany({

--- a/packages/backend/src/graphql/team/mutations/teamArchiveMutationField.test.ts
+++ b/packages/backend/src/graphql/team/mutations/teamArchiveMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const teamArchiveMutation = `
+const teamArchiveMutation = gql`
   mutation teamArchiveMutation($teamId: ID!) {
     teamArchive(teamId: $teamId) {
       id

--- a/packages/backend/src/graphql/team/mutations/teamCreateMutationField.test.ts
+++ b/packages/backend/src/graphql/team/mutations/teamCreateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const teamCreateMutation = `
+const teamCreateMutation = gql`
   mutation teamCreateMutation($data: TeamInput!) {
     teamCreate(data: $data) {
       title

--- a/packages/backend/src/graphql/team/mutations/teamUnarchiveMutationField.test.ts
+++ b/packages/backend/src/graphql/team/mutations/teamUnarchiveMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const teamUnarchiveMutation = `
+const teamUnarchiveMutation = gql`
   mutation teamUnarchiveMutation($id: ID!) {
     teamUnarchive(teamId: $id) {
       id

--- a/packages/backend/src/graphql/team/mutations/teamUpdateMutationField.test.ts
+++ b/packages/backend/src/graphql/team/mutations/teamUpdateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,10 +7,10 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const teamUpdateMutation = `
+const teamUpdateMutation = gql`
   mutation teamUpdateMutation($id: ID!, $data: TeamInput!) {
     teamUpdate(id: $id, data: $data) {
-      id 
+      id
       title
       slug
     }

--- a/packages/backend/src/graphql/team/queries/teamBySlugQueryField.test.ts
+++ b/packages/backend/src/graphql/team/queries/teamBySlugQueryField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const teamBySlugQuery = `
+const teamBySlugQuery = gql`
   query teamBySlug($teamSlug: String!) {
     teamBySlug(slug: $teamSlug) {
       id

--- a/packages/backend/src/graphql/team/queries/teamsQueryField.test.ts
+++ b/packages/backend/src/graphql/team/queries/teamsQueryField.test.ts
@@ -1,12 +1,14 @@
+import { gql } from 'apollo-server-core'
+
 import { PrismaClient, Team } from '@progwise/timebook-prisma'
 
 import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const teamsQuery = `
-  query teams ($includeArchived: Boolean) {
-    teams (includeArchived: $includeArchived) {
+const teamsQuery = gql`
+  query teams($includeArchived: Boolean) {
+    teams(includeArchived: $includeArchived) {
       id
       title
       slug

--- a/packages/backend/src/graphql/user/mutations/userCapacityUpdateMutationField.test.ts
+++ b/packages/backend/src/graphql/user/mutations/userCapacityUpdateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,13 +7,13 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const userCapacityUpdateMutation = `
+const userCapacityUpdateMutation = gql`
   mutation userCapacityUpdate($userId: ID!, $availableMinutesPerWeek: Int, $teamSlug: String!) {
     userCapacityUpdate(userId: $userId, availableMinutesPerWeek: $availableMinutesPerWeek, teamSlug: $teamSlug) {
       id
       availableMinutesPerWeek(teamSlug: $teamSlug)
     }
-}
+  }
 `
 
 describe('userCapacityUpdate', () => {

--- a/packages/backend/src/graphql/user/mutations/userRoleUpdateMutationField.test.ts
+++ b/packages/backend/src/graphql/user/mutations/userRoleUpdateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const userRoleUpdateMutation = `
+const userRoleUpdateMutation = gql`
   mutation userRoleUpdate($userId: ID!, $role: Role!, $teamSlug: String!) {
     userRoleUpdate(userId: $userId, role: $role, teamSlug: $teamSlug) {
       id

--- a/packages/backend/src/graphql/workHour/mutations/workHourCreateMutationField.test.ts
+++ b/packages/backend/src/graphql/workHour/mutations/workHourCreateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const workHourCreateMutation = `
+const workHourCreateMutation = gql`
   mutation workHourCreateMutation($data: WorkHourInput!) {
     workHourCreate(data: $data) {
       id

--- a/packages/backend/src/graphql/workHour/mutations/workHourDeleteMutationField.test.ts
+++ b/packages/backend/src/graphql/workHour/mutations/workHourDeleteMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const workHourDeleteMutation = `
+const workHourDeleteMutation = gql`
   mutation workHourDeleteMutation($id: ID!) {
     workHourDelete(id: $id) {
       id

--- a/packages/backend/src/graphql/workHour/mutations/workHourUpdateMutationField.test.ts
+++ b/packages/backend/src/graphql/workHour/mutations/workHourUpdateMutationField.test.ts
@@ -1,3 +1,4 @@
+import { gql } from 'apollo-server-core'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -6,7 +7,7 @@ import { getTestServer } from '../../../getTestServer'
 
 const prisma = new PrismaClient()
 
-const workHourUpdateMutation = `
+const workHourUpdateMutation = gql`
   mutation workHourUpdateMutation($id: ID!, $data: WorkHourInput!) {
     workHourUpdate(id: $id, data: $data) {
       id


### PR DESCRIPTION
Adds `gql` tag to every GraphQL operation in our backend tests.

Benefits:
- adds Prettier formation
- adds autocompletion
- display errors

<img width="660" alt="image" src="https://user-images.githubusercontent.com/1886867/203006253-f30e5fca-3e91-4b02-b3c5-e57f6d3bcd64.png">
<img width="447" alt="image" src="https://user-images.githubusercontent.com/1886867/203006481-61794f90-88e4-4dbc-8430-674ec3d6ce22.png">
<img width="517" alt="image" src="https://user-images.githubusercontent.com/1886867/203006612-f9c5e3f9-b412-457c-a9ab-37082f0385c7.png">
