### PR TITLE
test(frontend): fix unstable taskCell test

### DIFF
--- a/apps/web/frontend/components/taskList/taskCell.test.tsx
+++ b/apps/web/frontend/components/taskList/taskCell.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitForElementToBeRemoved } from '@testing-library/reac
 import userEvent from '@testing-library/user-event'
 import { Client, Provider } from 'urql'
 
+import '../../mocks/mockServer'
 import { testTask } from '../../mocks/testData'
 import { TaskCell } from './taskCell'
 

--- a/apps/web/frontend/mocks/taskHandlers.ts
+++ b/apps/web/frontend/mocks/taskHandlers.ts
@@ -1,4 +1,5 @@
-import { mockTaskCreateMutation, mockTaskDeleteMutation } from '../generated/graphql'
+import { mockTaskCreateMutation, mockTaskDeleteMutation, mockTaskUpdateMutation } from '../generated/graphql'
+import { testTask } from './testData'
 
 export const taskHandlers = [
   mockTaskDeleteMutation((request, response, context) =>
@@ -29,6 +30,18 @@ export const taskHandlers = [
           },
           title: request.variables.data.title,
           __typename: 'Task',
+        },
+      }),
+    ),
+  ),
+  mockTaskUpdateMutation((request, response, context) =>
+    response(
+      context.data({
+        __typename: 'Mutation',
+        taskUpdate: {
+          ...testTask,
+          id: request.variables.id,
+          title: request.variables.data.title,
         },
       }),
     ),


### PR DESCRIPTION
Fixes #563 by importing missing mock server for network requests in the tests.