### PR TITLE
feat: display work hours even when user is no longer project member

### DIFF
--- a/apps/web/frontend/components/weekTable/weekTableTaskRow.tsx
+++ b/apps/web/frontend/components/weekTable/weekTableTaskRow.tsx
@@ -21,6 +21,7 @@ const WeekTableTaskRowFragment = graphql(`
     }
     project {
       id
+      isProjectMember
     }
     tracking {
       ...TrackingButtonsTracking
@@ -57,6 +58,7 @@ export const WeekTableTaskRow = ({ interval, task: taskFragment }: WeekTableTask
           <WeekTableTaskDayCell
             day={day}
             disabled={
+              !task.project.isProjectMember ||
               (task.project.startDate ? isBefore(day, parseISO(task.project.startDate)) : false) ||
               (task.project.endDate ? isAfter(day, parseISO(task.project.endDate)) : false)
             }
@@ -70,9 +72,7 @@ export const WeekTableTaskRow = ({ interval, task: taskFragment }: WeekTableTask
       <TableCell className="text-center">
         <FormattedDuration minutes={taskDurations} title="" />
       </TableCell>
-      <TableCell>
-        <TaskLockButton task={task} />
-      </TableCell>
+      <TableCell>{task.project.isProjectMember && <TaskLockButton task={task} />}</TableCell>
     </TableRow>
   )
 }

--- a/apps/web/frontend/generated/gql/gql.ts
+++ b/apps/web/frontend/generated/gql/gql.ts
@@ -80,7 +80,7 @@ const documents = {
     types.WorkHourUpdateDocument,
   '\n  query isLocked($year: Int!, $month: Int!, $projectId: ID!, $userId: ID!, $taskId: ID!) {\n    report(year: $year, month: $month, projectId: $projectId, userId: $userId) {\n      isLocked\n    }\n    task(taskId: $taskId) {\n      isLockedByUser\n    }\n  }\n':
     types.IsLockedDocument,
-  '\n  fragment WeekTableTaskRow on Task {\n    id\n    title\n    project {\n      startDate\n      endDate\n    }\n    workHours(from: $from, to: $to) {\n      duration\n      date\n    }\n    project {\n      id\n    }\n    tracking {\n      ...TrackingButtonsTracking\n    }\n    ...TrackingButtonsTask\n    ...TaskLockButton\n  }\n':
+  '\n  fragment WeekTableTaskRow on Task {\n    id\n    title\n    project {\n      startDate\n      endDate\n    }\n    workHours(from: $from, to: $to) {\n      duration\n      date\n    }\n    project {\n      id\n      isProjectMember\n    }\n    tracking {\n      ...TrackingButtonsTracking\n    }\n    ...TrackingButtonsTask\n    ...TaskLockButton\n  }\n':
     types.WeekTableTaskRowFragmentDoc,
   '\n  query project($projectId: ID!) {\n    project(projectId: $projectId) {\n      id\n      ...TaskListProject\n      members {\n        ...ProjectMemberListUser\n      }\n      ...ProjectForm\n    }\n  }\n':
     types.ProjectDocument,
@@ -92,7 +92,7 @@ const documents = {
     types.ProjectCountsDocument,
   '\n  mutation projectCreate($data: ProjectInput!) {\n    projectCreate(data: $data) {\n      id\n    }\n  }\n':
     types.ProjectCreateDocument,
-  '\n  query weekTable($from: Date!, $to: Date) {\n    projects(from: $from, to: $to) {\n      ...WeekTableProject\n    }\n  }\n':
+  '\n  query weekTable($from: Date!, $to: Date) {\n    projects(from: $from, to: $to, includeProjectsWhereUserBookedWorkHours: true) {\n      ...WeekTableProject\n    }\n  }\n':
     types.WeekTableDocument,
 }
 
@@ -324,8 +324,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  fragment WeekTableTaskRow on Task {\n    id\n    title\n    project {\n      startDate\n      endDate\n    }\n    workHours(from: $from, to: $to) {\n      duration\n      date\n    }\n    project {\n      id\n    }\n    tracking {\n      ...TrackingButtonsTracking\n    }\n    ...TrackingButtonsTask\n    ...TaskLockButton\n  }\n',
-): typeof documents['\n  fragment WeekTableTaskRow on Task {\n    id\n    title\n    project {\n      startDate\n      endDate\n    }\n    workHours(from: $from, to: $to) {\n      duration\n      date\n    }\n    project {\n      id\n    }\n    tracking {\n      ...TrackingButtonsTracking\n    }\n    ...TrackingButtonsTask\n    ...TaskLockButton\n  }\n']
+  source: '\n  fragment WeekTableTaskRow on Task {\n    id\n    title\n    project {\n      startDate\n      endDate\n    }\n    workHours(from: $from, to: $to) {\n      duration\n      date\n    }\n    project {\n      id\n      isProjectMember\n    }\n    tracking {\n      ...TrackingButtonsTracking\n    }\n    ...TrackingButtonsTask\n    ...TaskLockButton\n  }\n',
+): typeof documents['\n  fragment WeekTableTaskRow on Task {\n    id\n    title\n    project {\n      startDate\n      endDate\n    }\n    workHours(from: $from, to: $to) {\n      duration\n      date\n    }\n    project {\n      id\n      isProjectMember\n    }\n    tracking {\n      ...TrackingButtonsTracking\n    }\n    ...TrackingButtonsTask\n    ...TaskLockButton\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -360,8 +360,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query weekTable($from: Date!, $to: Date) {\n    projects(from: $from, to: $to) {\n      ...WeekTableProject\n    }\n  }\n',
-): typeof documents['\n  query weekTable($from: Date!, $to: Date) {\n    projects(from: $from, to: $to) {\n      ...WeekTableProject\n    }\n  }\n']
+  source: '\n  query weekTable($from: Date!, $to: Date) {\n    projects(from: $from, to: $to, includeProjectsWhereUserBookedWorkHours: true) {\n      ...WeekTableProject\n    }\n  }\n',
+): typeof documents['\n  query weekTable($from: Date!, $to: Date) {\n    projects(from: $from, to: $to, includeProjectsWhereUserBookedWorkHours: true) {\n      ...WeekTableProject\n    }\n  }\n']
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {}

--- a/apps/web/frontend/generated/gql/graphql.ts
+++ b/apps/web/frontend/generated/gql/graphql.ts
@@ -163,9 +163,12 @@ export type Project = ModifyInterface & {
   id: Scalars['ID']
   /** Is the project locked for the given month */
   isLocked: Scalars['Boolean']
+  /** Is the user member of the project */
+  isProjectMember: Scalars['Boolean']
   /** List of users that are member of the project */
   members: Array<User>
   startDate?: Maybe<Scalars['Date']>
+  /** List of tasks that belong to the project. When the user is no longer a member of the project, only the tasks that the user booked work hours on are returned. */
   tasks: Array<Task>
   title: Scalars['String']
   workHours: Array<WorkHour>
@@ -221,6 +224,7 @@ export type QueryProjectArgs = {
 export type QueryProjectsArgs = {
   filter?: ProjectFilter
   from: Scalars['Date']
+  includeProjectsWhereUserBookedWorkHours?: Scalars['Boolean']
   to?: InputMaybe<Scalars['Date']>
 }
 
@@ -712,7 +716,13 @@ export type WeekTableTaskRowFragment = ({
   __typename?: 'Task'
   id: string
   title: string
-  project: { __typename?: 'Project'; startDate?: string | null; endDate?: string | null; id: string }
+  project: {
+    __typename?: 'Project'
+    startDate?: string | null
+    endDate?: string | null
+    id: string
+    isProjectMember: boolean
+  }
   workHours: Array<{ __typename?: 'WorkHour'; duration: number; date: string }>
   tracking?:
     | ({ __typename?: 'Tracking' } & {
@@ -1241,7 +1251,10 @@ export const WeekTableTaskRowFragmentDoc = {
             name: { kind: 'Name', value: 'project' },
             selectionSet: {
               kind: 'SelectionSet',
-              selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }],
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'isProjectMember' } },
+              ],
             },
           },
           {
@@ -1441,7 +1454,10 @@ export const WeekTableProjectRowGroupFragmentDoc = {
             name: { kind: 'Name', value: 'project' },
             selectionSet: {
               kind: 'SelectionSet',
-              selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }],
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'isProjectMember' } },
+              ],
             },
           },
           {
@@ -1608,7 +1624,10 @@ export const WeekTableProjectFragmentDoc = {
             name: { kind: 'Name', value: 'project' },
             selectionSet: {
               kind: 'SelectionSet',
-              selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }],
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'isProjectMember' } },
+              ],
             },
           },
           {
@@ -3343,6 +3362,11 @@ export const WeekTableDocument = {
                 name: { kind: 'Name', value: 'to' },
                 value: { kind: 'Variable', name: { kind: 'Name', value: 'to' } },
               },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'includeProjectsWhereUserBookedWorkHours' },
+                value: { kind: 'BooleanValue', value: true },
+              },
             ],
             selectionSet: {
               kind: 'SelectionSet',
@@ -3466,7 +3490,10 @@ export const WeekTableDocument = {
             name: { kind: 'Name', value: 'project' },
             selectionSet: {
               kind: 'SelectionSet',
-              selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }],
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'isProjectMember' } },
+              ],
             },
           },
           {

--- a/apps/web/frontend/mocks/mocks.generated.ts
+++ b/apps/web/frontend/mocks/mocks.generated.ts
@@ -165,9 +165,12 @@ export type Project = ModifyInterface & {
   id: Scalars['ID']
   /** Is the project locked for the given month */
   isLocked: Scalars['Boolean']
+  /** Is the user member of the project */
+  isProjectMember: Scalars['Boolean']
   /** List of users that are member of the project */
   members: Array<User>
   startDate?: Maybe<Scalars['Date']>
+  /** List of tasks that belong to the project. When the user is no longer a member of the project, only the tasks that the user booked work hours on are returned. */
   tasks: Array<Task>
   title: Scalars['String']
   workHours: Array<WorkHour>
@@ -223,6 +226,7 @@ export type QueryProjectArgs = {
 export type QueryProjectsArgs = {
   filter?: ProjectFilter
   from: Scalars['Date']
+  includeProjectsWhereUserBookedWorkHours?: Scalars['Boolean']
   to?: InputMaybe<Scalars['Date']>
 }
 
@@ -667,7 +671,13 @@ export type WeekTableProjectFragment = {
     isLocked: boolean
     isLockedByUser: boolean
     workHours: Array<{ __typename?: 'WorkHour'; duration: number; date: string }>
-    project: { __typename?: 'Project'; startDate?: string | null; endDate?: string | null; id: string }
+    project: {
+      __typename?: 'Project'
+      startDate?: string | null
+      endDate?: string | null
+      id: string
+      isProjectMember: boolean
+    }
     tracking?: {
       __typename?: 'Tracking'
       start: string
@@ -688,7 +698,13 @@ export type WeekTableProjectRowGroupFragment = {
     title: string
     isLocked: boolean
     isLockedByUser: boolean
-    project: { __typename?: 'Project'; startDate?: string | null; endDate?: string | null; id: string }
+    project: {
+      __typename?: 'Project'
+      startDate?: string | null
+      endDate?: string | null
+      id: string
+      isProjectMember: boolean
+    }
     workHours: Array<{ __typename?: 'WorkHour'; duration: number; date: string }>
     tracking?: {
       __typename?: 'Tracking'
@@ -729,7 +745,13 @@ export type WeekTableTaskRowFragment = {
   title: string
   isLocked: boolean
   isLockedByUser: boolean
-  project: { __typename?: 'Project'; startDate?: string | null; endDate?: string | null; id: string }
+  project: {
+    __typename?: 'Project'
+    startDate?: string | null
+    endDate?: string | null
+    id: string
+    isProjectMember: boolean
+  }
   workHours: Array<{ __typename?: 'WorkHour'; duration: number; date: string }>
   tracking?: {
     __typename?: 'Tracking'
@@ -823,7 +845,13 @@ export type WeekTableQuery = {
       isLocked: boolean
       isLockedByUser: boolean
       workHours: Array<{ __typename?: 'WorkHour'; duration: number; date: string }>
-      project: { __typename?: 'Project'; startDate?: string | null; endDate?: string | null; id: string }
+      project: {
+        __typename?: 'Project'
+        startDate?: string | null
+        endDate?: string | null
+        id: string
+        isProjectMember: boolean
+      }
       tracking?: {
         __typename?: 'Tracking'
         start: string

--- a/apps/web/frontend/mocks/projectHandlers.ts
+++ b/apps/web/frontend/mocks/projectHandlers.ts
@@ -25,7 +25,7 @@ export const projectHandlers = [
                 id: 'task1',
                 title: 'Task 1',
                 workHours: [],
-                project: { id: testProject1.id },
+                project: { id: testProject1.id, isProjectMember: true },
                 isLocked: false,
                 isLockedByUser: false,
               },

--- a/apps/web/pages/week/index.page.tsx
+++ b/apps/web/pages/week/index.page.tsx
@@ -10,7 +10,7 @@ import { graphql } from '../../frontend/generated/gql'
 
 const weekTableQueryDocument = graphql(`
   query weekTable($from: Date!, $to: Date) {
-    projects(from: $from, to: $to) {
+    projects(from: $from, to: $to, includeProjectsWhereUserBookedWorkHours: true) {
       ...WeekTableProject
     }
   }

--- a/packages/backend/src/graphql/generated/schema.graphql
+++ b/packages/backend/src/graphql/generated/schema.graphql
@@ -174,6 +174,11 @@ type Project implements ModifyInterface {
   ): Boolean!
 
   """
+  Is the user member of the project
+  """
+  isProjectMember: Boolean!
+
+  """
   List of users that are member of the project
   """
   members(
@@ -183,6 +188,10 @@ type Project implements ModifyInterface {
     includePastMembers: Boolean! = false
   ): [User!]!
   startDate: Date
+
+  """
+  List of tasks that belong to the project. When the user is no longer a member of the project, only the tasks that the user booked work hours on are returned.
+  """
   tasks(showArchived: Boolean! = false): [Task!]!
   title: String!
   workHours: [WorkHour!]!
@@ -217,7 +226,16 @@ type Query {
   """
   Returns all project of the signed in user that are active
   """
-  projects(filter: ProjectFilter! = ACTIVE, from: Date!, to: Date): [Project!]!
+  projects(
+    filter: ProjectFilter! = ACTIVE
+    from: Date!
+
+    """
+    If true, projects where the user is no longer a project member but booked work hours in the given time frame are included.
+    """
+    includeProjectsWhereUserBookedWorkHours: Boolean! = false
+    to: Date
+  ): [Project!]!
   projectsCount(filter: ProjectFilter!, from: Date!, to: Date): Int!
 
   """

--- a/packages/backend/src/graphql/project/project.ts
+++ b/packages/backend/src/graphql/project/project.ts
@@ -19,14 +19,22 @@ export const Project = builder.prismaObject('Project', {
       select: { tasks: { select: { workHours: { select: { id: true } } } } },
       resolve: (project) => project.tasks.flatMap((task) => task.workHours),
     }),
-    tasks: t.relation('tasks', {
+    tasks: t.withAuth({ isLoggedIn: true }).relation('tasks', {
+      description:
+        'List of tasks that belong to the project. When the user is no longer a member of the project, only the tasks that the user booked work hours on are returned.',
       args: {
         showArchived: t.arg.boolean({ defaultValue: false }),
       },
-      query: ({ showArchived }) => ({
+      query: ({ showArchived }, context) => ({
         where: {
           // eslint-disable-next-line unicorn/no-null
           archivedAt: showArchived ? undefined : null,
+          OR: [
+            // the user is project member:
+            { project: { projectMemberships: { some: { userId: context.session.user.id } } } },
+            // the user booked work hours on the task:
+            { workHours: { some: { userId: context.session.user.id } } },
+          ],
         },
         orderBy: { title: 'asc' },
       }),
@@ -90,6 +98,17 @@ export const Project = builder.prismaObject('Project', {
         })
 
         return !!lockedMonth
+      },
+    }),
+    isProjectMember: t.withAuth({ isLoggedIn: true }).boolean({
+      description: 'Is the user member of the project',
+      select: { id: true },
+      resolve: async (project, _arguments, context) => {
+        const projectMembership = await prisma.projectMembership.findUnique({
+          where: { userId_projectId: { projectId: project.id, userId: context.session.user.id } },
+        })
+
+        return !!projectMembership
       },
     }),
   }),

--- a/packages/backend/src/graphql/project/queries/projectsQueryField.test.ts
+++ b/packages/backend/src/graphql/project/queries/projectsQueryField.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable unicorn/no-null */
 import { gql } from 'apollo-server-core'
+import { format } from 'date-fns'
 import { GraphQLError } from 'graphql'
 
 import { PrismaClient } from '@progwise/timebook-prisma'
@@ -9,15 +10,20 @@ import { getTestServer } from '../../../getTestServer'
 const prisma = new PrismaClient()
 
 const projectsQuery = gql`
-  query projects($from: Date!, $includePastMembers: Boolean) {
-    projects(from: $from) {
+  query projects($from: Date!, $includePastMembers: Boolean, $includeProjectsWhereUserBookedWorkHours: Boolean) {
+    projects(from: $from, includeProjectsWhereUserBookedWorkHours: $includeProjectsWhereUserBookedWorkHours) {
       id
       title
       startDate
       endDate
+      isProjectMember
       members(includePastMembers: $includePastMembers) {
         id
         name
+      }
+      tasks {
+        id
+        title
       }
     }
   }
@@ -41,15 +47,18 @@ beforeEach(async () => {
       id: 'P1',
       title: 'Project 1',
       tasks: {
-        create: {
-          id: 'T1',
-          title: 'Task 1',
-          workHours: { create: { date: new Date(), userId: '2', duration: 60 } },
+        createMany: {
+          data: [
+            { id: 'T1', title: 'Task 1' },
+            { id: 'T2', title: 'Task 2' },
+          ],
         },
       },
       projectMemberships: { create: { userId: '1' } },
     },
   })
+
+  await prisma.workHour.create({ data: { date: new Date(), userId: '2', duration: 60, taskId: 'T1' } })
 })
 
 it('should throw error when not signed in', async () => {
@@ -58,6 +67,45 @@ it('should throw error when not signed in', async () => {
 
   expect(response.data).toBeNull()
   expect(response.errors).toEqual([new GraphQLError('Not authorized')])
+})
+
+describe('projects where the user is no longer member of', () => {
+  it('should return projects where the user booked work hours but is no longer member of', async () => {
+    const testServer = getTestServer({ userId: '2' })
+    const from = format(new Date(), 'yyyy-MM-dd')
+
+    const response = await testServer.executeOperation({
+      query: projectsQuery,
+      variables: { from, includeProjectsWhereUserBookedWorkHours: true },
+    })
+
+    expect(response.errors).toBeUndefined()
+    expect(response.data?.projects).toHaveLength(1)
+  })
+
+  it('should return only the tasks where the user booked work hours', async () => {
+    const testServer = getTestServer({ userId: '2' })
+    const from = format(new Date(), 'yyyy-MM-dd')
+
+    const response = await testServer.executeOperation({
+      query: projectsQuery,
+      variables: { from, includeProjectsWhereUserBookedWorkHours: true },
+    })
+
+    expect(response.data?.projects.at(0)?.tasks).toEqual([{ id: 'T1', title: 'Task 1' }])
+  })
+
+  it('should not return projects where the user booked work hours but is no longer member of when it was not booked in the given time frame', async () => {
+    const testServer = getTestServer({ userId: '2' })
+
+    const response = await testServer.executeOperation({
+      query: projectsQuery,
+      variables: { from: '2000-01-01', includeProjectsWhereUserBookedWorkHours: true },
+    })
+
+    expect(response.errors).toBeUndefined()
+    expect(response.data).toEqual({ projects: [] })
+  })
 })
 
 describe('members', () => {
@@ -76,7 +124,9 @@ describe('members', () => {
           title: 'Project 1',
           startDate: null,
           endDate: null,
+          isProjectMember: true,
           members: [{ id: '1', name: 'user with project membership' }],
+          tasks: expect.any(Array),
         },
       ],
     })
@@ -97,10 +147,12 @@ describe('members', () => {
           title: 'Project 1',
           startDate: null,
           endDate: null,
+          isProjectMember: true,
           members: [
             { id: '2', name: 'user without project membership who booked on project' },
             { id: '1', name: 'user with project membership' },
           ],
+          tasks: expect.any(Array),
         },
       ],
     })

--- a/packages/backend/src/graphql/project/queries/projectsQueryField.ts
+++ b/packages/backend/src/graphql/project/queries/projectsQueryField.ts
@@ -12,18 +12,50 @@ builder.queryField('projects', (t) =>
       from: t.arg({ type: DateScalar, required: true }),
       to: t.arg({ type: DateScalar, required: false }),
       filter: t.arg({ type: ProjectFilterEnum, defaultValue: ProjectFilter.ACTIVE }),
+      includeProjectsWhereUserBookedWorkHours: t.arg.boolean({
+        defaultValue: false,
+        description:
+          'If true, projects where the user is no longer a project member but booked work hours in the given time frame are included.',
+      }),
     },
-    resolve: (query, _source, { from, to, filter }, context) =>
+    resolve: (query, _source, { from, to, filter, includeProjectsWhereUserBookedWorkHours }, context) =>
       prisma.project.findMany({
         ...query,
-        where: {
-          ...getWhereFromProjectFilter(filter, from, to ?? from),
-          projectMemberships: {
-            some: {
-              userId: context.session.user.id,
+        where: includeProjectsWhereUserBookedWorkHours
+          ? {
+              ...getWhereFromProjectFilter(filter, from, to ?? from),
+              OR: [
+                // get projects where user is member
+                {
+                  projectMemberships: {
+                    some: {
+                      userId: context.session.user.id,
+                    },
+                  },
+                },
+                // or get projects where user booked work hours
+                {
+                  tasks: {
+                    some: {
+                      workHours: {
+                        some: {
+                          userId: context.session.user.id,
+                          AND: [{ date: { gte: from } }, { date: { lte: to ?? from } }],
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            }
+          : {
+              ...getWhereFromProjectFilter(filter, from, to ?? from),
+              projectMemberships: {
+                some: {
+                  userId: context.session.user.id,
+                },
+              },
             },
-          },
-        },
         orderBy: { title: 'asc' },
       }),
   }),

--- a/packages/backend/src/graphql/workHour/queries/workHoursQueryField.ts
+++ b/packages/backend/src/graphql/workHour/queries/workHoursQueryField.ts
@@ -22,13 +22,6 @@ builder.queryField('workHours', (t) =>
       prisma.workHour.findMany({
         ...query,
         where: {
-          task: {
-            project: {
-              projectMemberships: {
-                some: { userId: context.session.user.id },
-              },
-            },
-          },
           userId: { in: userIds?.map((id) => id.toString()) ?? [context.session.user.id] },
           date: {
             gte: from,


### PR DESCRIPTION
closes #734

I created a new project with two tasks and no members. Then I manually booked a work hour for me on one of the two tasks.
As the result, I was able to view by booked work hour: 

<img width="1452" alt="image" src="https://user-images.githubusercontent.com/1886867/232427281-9006d6be-2c8d-454f-8e23-d69e4dc0ab8d.png">
