### PR TITLE
fix: position of input loading spinner

### DIFF
--- a/apps/web/frontend/components/calendarSelector.tsx
+++ b/apps/web/frontend/components/calendarSelector.tsx
@@ -109,26 +109,25 @@ export const CalendarSelector = (props: CalendarSelectorProps): JSX.Element => {
         </Popover.Button>
 
         <Transition
+          className="z-10 w-80 rounded-xl border-2 bg-gray-200 p-2 text-sm dark:bg-slate-800 dark:text-white"
           enter="transition duration-100 ease-out"
           enterFrom="transform scale-75 opacity-0"
           enterTo="transform scale-100 opacity-100"
           leave="transition duration-100 ease-out"
           leaveFrom="transform scale-100 opacity-100"
           leaveTo="transform scale-75 opacity-0"
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+          }}
+          ref={floating}
+          data-testid="calendar-popover"
         >
-          <Popover.Panel className="absolute z-10">
+          <Popover.Panel>
             {({ close }) => (
-              <section
-                ref={floating}
-                style={{
-                  position: strategy,
-                  top: y ?? 0,
-                  left: x ?? 0,
-                }}
-                className="w-80 rounded-xl border-2 bg-gray-200 p-2 text-sm dark:bg-slate-800 dark:text-white"
-                data-testid="calendar-popover"
-              >
-                <header className="flex justify-between p-0 pb-2 font-bold">
+              <>
+                <header className="flex justify-between pb-2 font-bold">
                   <CalendarIcon label="Go to previous month" onClick={gotoPreviousMonth}>
                     <BiLeftArrow />
                   </CalendarIcon>
@@ -163,7 +162,7 @@ export const CalendarSelector = (props: CalendarSelectorProps): JSX.Element => {
                     />
                   ))}
                 </div>
-              </section>
+              </>
             )}
           </Popover.Panel>
         </Transition>

--- a/packages/ui/src/inputField/inputField.tsx
+++ b/packages/ui/src/inputField/inputField.tsx
@@ -63,7 +63,7 @@ export const InputField = React.forwardRef(
             {label}
           </label>
         )}
-        <span>
+        <span className="relative">
           <input
             aria-label={label}
             className={`w-full rounded-md ${


### PR DESCRIPTION
fixes #725

The bug could be solved with a `position: relative` in the input. But this caused that inputs were always displayed above the `CalendarSelector`. Therefore, I had to repair the positioning inside the `CalendarSelector` as well.

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/1886867/233366387-6d1bf5a6-4a01-4935-9841-9d58b8c9803b.png">
