### PR TITLE
fix: add correct prisma engine binary target for alpine linux

### DIFF
--- a/packages/backend/src/prisma/schema.prisma
+++ b/packages/backend/src/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 
 generator client {
   provider        = "prisma-client-js"
-  binaryTargets   = ["native", "debian-openssl-1.1.x"]
+  binaryTargets   = ["native", "debian-openssl-1.1.x", "linux-musl-openssl-3.0.x"]
   previewFeatures = []
   output          = "../../../../node_modules/@progwise/timebook-prisma"
 }


### PR DESCRIPTION
see https://www.prisma.io/docs/orm/reference/prisma-schema-reference#linux-alpine-on-x86_64-architectures