### PR TITLE
Fix/org-view-subscribe-btn-margin

### DIFF
--- a/apps/web/frontend/components/organizationForm/subscribeOrUnsubscribeOrganizationButton/subscribeOrUnsubscribeOrganizationButton.tsx
+++ b/apps/web/frontend/components/organizationForm/subscribeOrUnsubscribeOrganizationButton/subscribeOrUnsubscribeOrganizationButton.tsx
@@ -24,7 +24,7 @@ export const SubscribeOrUnsubscribeOrganizationButton = (props: SubscribeOrUnsub
   }
 
   return (
-    <Link className="btn btn-primary btn-sm" href={`/organizations/${organization.id}/checkout`}>
+    <Link className="btn btn-primary btn-sm mb-8" href={`/organizations/${organization.id}/checkout`}>
       {organization.subscriptionStatus === 'CANCELLED' ? 'Renew' : 'Subscribe'}
     </Link>
   )


### PR DESCRIPTION
Closes #989

Adds a margin at the bottom of the `Subscribe` button on the organization details page.